### PR TITLE
Clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# Test Prompt Video
+# 🎞️ Open Source Video Generator
+
+Generate a one‑minute video from a text prompt entirely offline on macOS using open‑source tools. The pipeline handles script writing, image creation, voice synthesis, optional animation, and final assembly on Apple Silicon machines.
+
+## ✨ Features
+- Emotion-aware script generation with large language models
+- Style-specific images via Stable Diffusion with optional LoRA
+- Optional lipsync animation using SadTalker
+- Expressive voice-over with Coqui TTS
+- Automatic or custom background music using Audiocraft MusicGen
+- Crossfades and zoom effects during video assembly
+- Runs locally with no API keys once models are downloaded
+
+## 🖥 Requirements
+- macOS 12+ on Apple Silicon (M1/M2) with at least 16 GB RAM
+- Python 3.10 or newer
+- ~15 GB free disk space for model caches
+
+## 🔧 Setup
+Create the virtual environment, install dependencies, and enable PyTorch MPS:
+
+```bash
+bash setup_macos.sh
+source venv/bin/activate
+```
+
+## 🚀 Usage
+Generate a Pixar-style inspirational clip:
+
+```bash
+python main.py --prompt "a boy overcomes fear" --emotion inspirational --style pixar --speaker tts_models/en/vctk/vits --music auto --animate --output final_video.mp4
+```
+
+### CLI Flags
+| Flag | Description |
+|------|-------------|
+| `--prompt` | text prompt for the video |
+| `--emotion` | emotion context (default `happy`) |
+| `--style` | image style preset (`anime`, `pixar`, `realistic`) |
+| `--speaker` | TTS voice model or speaker file |
+| `--lora` | path to LoRA weights for diffusion |
+| `--music` | `auto` to use MusicGen or path to mp3 |
+| `--animate` | enable SadTalker animation |
+| `--output` | output video path |
+
+## 🏗 Components
+1. **Script Generator** – Mistral‑7B‑Instruct via `transformers`
+2. **Image Generator** – Stable Diffusion with style presets and LoRA support
+3. **Animation** – SadTalker lipsync or Ken Burns fallback
+4. **Voice Synthesizer** – Coqui TTS with emotion tags
+5. **Music** – Audiocraft MusicGen or provided track
+6. **Video Editor** – MoviePy crossfades, zooms and audio mixing
+
+## ✅ Testing
+Run static compilation and unit tests:
+
+```bash
+python -m py_compile $(find . -name '*.py')
+python test_pipeline.py
+```
+
+## 🌟 Preview
+> Add a preview GIF here
+
+## ⚖️ License
+MIT

--- a/core/animation.py
+++ b/core/animation.py
@@ -1,0 +1,26 @@
+"""Animation utilities."""
+import logging
+from pathlib import Path
+
+import subprocess
+
+
+def animate_image(image_path: Path, audio_path: Path, result_dir: Path) -> Path:
+    """Use SadTalker to animate an image based on speech audio."""
+    logging.info("Animating %s with SadTalker", image_path)
+    try:
+        subprocess.run([
+            "sadtalker",
+            "--driven_audio",
+            str(audio_path),
+            "--source_image",
+            str(image_path),
+            "--result_dir",
+            str(result_dir),
+        ], check=True)
+        gen = result_dir / "results" / "driven_audio" / image_path.stem / "result.mp4"
+        if gen.exists():
+            return gen
+    except Exception as e:
+        logging.warning("SadTalker failed: %s", e)
+    return image_path

--- a/core/audio_generator.py
+++ b/core/audio_generator.py
@@ -1,0 +1,17 @@
+"""Audio and voice generation module."""
+import logging
+from pathlib import Path
+from typing import Optional
+
+from TTS.api import TTS
+
+
+def generate_audio(text: str, emotion: str, speaker: Optional[str], tmpdir: Path) -> Path:
+    """Generate emotion aware speech audio."""
+    model = speaker or "tts_models/en/vctk/vits"
+    logging.info("Generating audio with model %s", model)
+    tts = TTS(model_name=model, progress_bar=False)
+    tts_kwargs = {"speaker_wav": speaker} if speaker and speaker.endswith(".wav") else {}
+    audio_path = tmpdir / f"speech_{hash(text)}.wav"
+    tts.tts_to_file(text=f"<emotion>{emotion}</emotion> {text}", file_path=str(audio_path), **tts_kwargs)
+    return audio_path

--- a/core/image_generator.py
+++ b/core/image_generator.py
@@ -1,0 +1,39 @@
+"""Image generation and animation using Stable Diffusion and LoRA."""
+import logging
+from pathlib import Path
+from typing import Optional
+
+from diffusers import StableDiffusionPipeline
+import torch
+from PIL import Image
+
+STYLE_MODELS = {
+    "pixar": "nerijs/pixart-alpha",
+    "anime": "Linaqruf/anything-v3.0",
+    "realistic": "runwayml/stable-diffusion-v1-5",
+}
+
+
+def load_pipeline(style: str) -> StableDiffusionPipeline:
+    model_name = STYLE_MODELS.get(style, STYLE_MODELS["realistic"])
+    logging.info("Loading diffusion model %s", model_name)
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float16)
+    device = (
+        "cuda"
+        if torch.cuda.is_available()
+        else "mps" if torch.backends.mps.is_available() else "cpu"
+    )
+    pipe.to(device)
+    return pipe
+
+
+def generate_image(prompt: str, emotion: str, style: str, lora: Optional[str] = None) -> Image.Image:
+    pipe = load_pipeline(style)
+    if lora:
+        logging.info("Loading LoRA weights %s", lora)
+        pipe.load_lora_weights(lora)
+        pipe.fuse_lora()
+    formatted = f"{prompt}, dreamy, {emotion}, ultra-detailed"
+    logging.info("Generating image with prompt: %s", formatted)
+    image = pipe(formatted).images[0]
+    return image

--- a/core/script_generator.py
+++ b/core/script_generator.py
@@ -1,0 +1,22 @@
+"""Script generation module."""
+import logging
+from typing import List
+
+from transformers import pipeline
+
+
+def generate_script(prompt: str, emotion: str, model: str = "mistralai/Mistral-7B-Instruct") -> List[str]:
+    """Generate six short script segments using a large language model."""
+    logging.info("Generating script with model %s", model)
+    text_gen = pipeline("text-generation", model=model, device_map="auto")
+    base_prompt = (
+        f"Write a cinematic six part script for a one minute video about: {prompt}. "
+        f"Each part should be roughly ten seconds long and convey a {emotion} tone."
+    )
+    output = text_gen(base_prompt, max_new_tokens=200, do_sample=True)[0]["generated_text"]
+    sentences = [s.strip() for s in output.split("\n") if s.strip()]
+    if len(sentences) < 6:
+        sentences = [s.strip() for s in output.split(".") if s.strip()]
+    if len(sentences) < 6:
+        sentences += ["..."] * (6 - len(sentences))
+    return sentences[:6]

--- a/core/video_editor.py
+++ b/core/video_editor.py
@@ -1,0 +1,48 @@
+"""Video editing and assembly module."""
+import logging
+from pathlib import Path
+from typing import List, Union
+import tempfile
+
+from PIL import Image
+from moviepy.editor import (
+    ImageClip,
+    AudioFileClip,
+    VideoFileClip,
+    concatenate_videoclips,
+    CompositeAudioClip,
+    vfx,
+)
+
+
+def _image_to_clip(img: Union[Image.Image, Path]) -> ImageClip:
+    if isinstance(img, Path):
+        if img.suffix == ".mp4":
+            return VideoFileClip(str(img)).subclip(0, 10)
+        return ImageClip(str(img)).set_duration(10)
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fp:
+            img.save(fp.name)
+            return ImageClip(fp.name).set_duration(10)
+
+
+def assemble_video(
+    clips: List[Union[Image.Image, Path]],
+    audios: List[Path],
+    music: Path,
+    out_path: Path,
+) -> None:
+    """Combine clips, audio and music into a final mp4."""
+    logging.info("Assembling final video")
+    video_clips = []
+    for img, audio in zip(clips, audios):
+        clip = _image_to_clip(img)
+        clip = clip.fx(vfx.fadein, 0.5).fx(vfx.fadeout, 0.5)
+        clip = clip.fx(vfx.zoom_in, 1.05)
+        clip = clip.set_audio(AudioFileClip(str(audio)).set_duration(10))
+        video_clips.append(clip)
+    final = concatenate_videoclips(video_clips, method="compose")
+    if music and music.exists():
+        bg = AudioFileClip(str(music)).volumex(0.3).audio_loop(duration=final.duration)
+        final = final.set_audio(CompositeAudioClip([final.audio, bg]))
+    final.write_videofile(str(out_path), fps=24)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,69 @@
+"""Command line interface for the video generation pipeline."""
+import argparse
+import logging
+from pathlib import Path
+import tempfile
+
+from core.script_generator import generate_script
+from core.image_generator import generate_image
+from core.audio_generator import generate_audio
+from core.animation import animate_image
+from core.video_editor import assemble_video
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate a 1-minute video from a prompt")
+    p.add_argument("--prompt", required=True, help="Text prompt for the video")
+    p.add_argument("--emotion", default="happy", help="Emotion for the video")
+    p.add_argument("--style", default="realistic", help="Visual style preset")
+    p.add_argument("--speaker", default=None, help="TTS speaker or model")
+    p.add_argument("--lora", default=None, help="LoRA weights for image generation")
+    p.add_argument("--music", default="auto", help="'auto' or path to mp3")
+    p.add_argument("--animate", action="store_true", help="Enable SadTalker animation")
+    p.add_argument("--output", default="output.mp4", help="Output video file")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    logging.info("Arguments: %s", args)
+
+    segments = generate_script(args.prompt, args.emotion)
+
+    images = []
+    audios = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        for idx, segment in enumerate(segments):
+            img = generate_image(segment, args.emotion, args.style, args.lora)
+            audio = generate_audio(segment, args.emotion, args.speaker, tmpdir)
+            if args.animate:
+                img_path = tmpdir / f"img_{idx}.png"
+                img.save(img_path)
+                video = animate_image(img_path, audio, tmpdir)
+                images.append(video)
+            else:
+                images.append(img)
+            audios.append(audio)
+
+        music_path = Path(args.music)
+        if args.music == "auto":
+            try:
+                from audiocraft.models import MusicGen
+                logging.info("Generating background music with MusicGen")
+                model = MusicGen.get_pretrained("facebook/musicgen-small")
+                music_wave = model.generate([f"{args.emotion} background music"], progress=True)
+                music_path = tmpdir / "music.wav"
+                model.save_wav(music_wave[0], music_path)
+            except Exception as e:
+                logging.warning("Music generation failed: %s", e)
+                music_path = Path()
+        assemble_video(images, audios, music_path, Path(args.output))
+
+    logging.info("Video saved to %s", args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+transformers
+torch
+torchaudio
+Pillow
+diffusers
+accelerate
+moviepy
+opencv-python
+ffmpeg-python
+audiocraft
+tts==0.17.1
+huggingface-hub
+gradio

--- a/setup_macos.sh
+++ b/setup_macos.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Setup environment for macOS (Apple Silicon)
+set -e
+
+python3 -m venv venv
+source venv/bin/activate
+
+pip install --upgrade pip
+# Install PyTorch with MPS support
+pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+
+pip install -r requirements.txt
+
+echo "Environment ready. Activate with 'source venv/bin/activate'"

--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -1,0 +1,14 @@
+"""Simple unit tests for the pipeline."""
+from pathlib import Path
+
+from core.script_generator import generate_script
+
+
+def test_script_generation():
+    segs = generate_script("a cat jumps over a wall", "exciting", model="hf-internal-testing/tiny-random-gpt2")
+    assert len(segs) == 6
+
+
+if __name__ == "__main__":
+    test_script_generation()
+    print("All tests passed")

--- a/web_ui.py
+++ b/web_ui.py
@@ -1,0 +1,43 @@
+"""Minimal Gradio UI for the video pipeline."""
+import gradio as gr
+from pathlib import Path
+import tempfile
+
+from core.script_generator import generate_script
+from core.image_generator import generate_image
+from core.audio_generator import generate_audio
+from core.video_editor import assemble_video
+from core.animation import animate_image
+
+
+def run_pipeline(prompt, emotion, style):
+    segments = generate_script(prompt, emotion)
+    images = []
+    audios = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        for idx, seg in enumerate(segments):
+            img = generate_image(seg, emotion, style)
+            audio = generate_audio(seg, emotion, None, tmpdir)
+            img_path = tmpdir / f"img{idx}.png"
+            img.save(img_path)
+            video = animate_image(img_path, audio, tmpdir)
+            images.append(video)
+            audios.append(audio)
+        out = tmpdir / "out.mp4"
+        assemble_video(images, audios, Path(), out)
+        return out
+
+
+def app():
+    iface = gr.Interface(
+        fn=run_pipeline,
+        inputs=[gr.Textbox(), gr.Textbox(value="happy"), gr.Dropdown(["anime", "pixar", "realistic"], value="anime")],
+        outputs=gr.Video(),
+    )
+    iface.launch()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()
+


### PR DESCRIPTION
## Summary
- clarify setup and usage in README
- keep single Requirements, Setup, and Usage sections
- retain CLI flags and component overview

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `python test_pipeline.py` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68400239817c832db4104f99be520503