### PR TITLE
Add spacy and pin typer for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository contains a modular pipeline to generate a **1-minute video** fro
 - Python 3.10 or **3.11** (Python 3.12 is currently unsupported by the `tts` package)
 - At least 16 GB RAM recommended
 - ~15 GB free disk space for cached models
+- `typer` is pinned to `<1.0` to satisfy both `gradio` and `spacy`
 
 If you manage multiple Python versions, `pyenv` can help select 3.11:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ ffmpeg-python==0.2.0
 audiocraft==0.0.2
 tts==0.17.1 ; python_version < "3.12"
 gradio==4.16.0
+spacy==3.8.7
+typer>=0.9,<1.0


### PR DESCRIPTION
## Summary
- include `spacy` and pin `typer` for compatibility with gradio
- note `typer` pinning in README

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `python test_pipeline.py` *(fails: ModuleNotFoundError: No module named 'transformers')*
- `pip install -r requirements.txt` *(fails: subprocess-exited-with-error building numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68418efdf7a0832d94907226990a66f5